### PR TITLE
Update plugin for Greebo

### DIFF
--- a/action.php
+++ b/action.php
@@ -39,8 +39,10 @@ class action_plugin_diffpreview extends DokuWiki_Action_Plugin {
 			|| is_array($action) && array_key_exists('changes', $action)
 		)) return;
 
-		/* Check for DokuWiki release Greebo and above */
+		/* We check the DokuWiki release */
 		if (class_exists('\\dokuwiki\\ActionRouter', false)) {
+			/* release Greebo (and above) */
+
 			/* See ActionRouter->setupAction() and Action\Preview */
 			$ae = new dokuwiki\Action\Edit();
 			$ae->checkPreconditions();
@@ -49,17 +51,25 @@ class action_plugin_diffpreview extends DokuWiki_Action_Plugin {
 
 			$event->stopPropagation();
 			$event->preventDefault();
-		} else /* DokuWiki release Frusterick Manners or below */
+
+		} elseif (function_exists('act_permcheck')) {
+			/* Release Frusterick Manners and below */
+
 			// Same setup as preview: permissions and environment
 			if ('preview' == act_permcheck('preview')
-			&& 'preview' == act_edit('preview'))
-		{
-			act_draftsave('preview');
-			$ACT = 'changes';
+				&& 'preview' == act_edit('preview'))
+			{
+				act_draftsave('preview');
+				$ACT = 'changes';
 
-			$event->stopPropagation();
-			$event->preventDefault();
+				$event->stopPropagation();
+				$event->preventDefault();
+			} else {
+				$ACT = 'preview';
+			}
+
 		} else {
+			// Fallback
 			$ACT = 'preview';
 		}
 	}

--- a/action.php
+++ b/action.php
@@ -30,8 +30,14 @@ class action_plugin_diffpreview extends DokuWiki_Action_Plugin {
 	function _action_act_preprocess(Doku_Event $event, $param) {
 		global $ACT;
 		global $INFO;
+;
+		$action =& $event->data;
 
-		if ($event->data != 'changes') return;
+		if (!( /* Valid cases */
+			$action == 'changes' // Greebo
+			// Frusterick Manners and below... probably
+			|| is_array($action) && array_key_exists('changes', $action)
+		)) return;
 
 		/* Check for DokuWiki release Greebo and above */
 		if (class_exists('\\dokuwiki\\ActionRouter', false)) {
@@ -41,18 +47,19 @@ class action_plugin_diffpreview extends DokuWiki_Action_Plugin {
 			$this->savedraft();
 			$ae->preProcess();
 
+			$event->stopPropagation();
 			$event->preventDefault();
-		}
-		else if('preview' == act_permcheck('preview')
-			&& 'preview' == act_draftsave('preview')
-			&& $INFO['editable']
-			&& 'preview' == act_edit('preview')) {
-			// DokuWiki releases before Greebo
+		} else /* DokuWiki release Frusterick Manners or below */
+			// Same setup as preview: permissions and environment
+			if ('preview' == act_permcheck('preview')
+			&& 'preview' == act_edit('preview'))
+		{
+			act_draftsave('preview');
 			$ACT = 'changes';
-			$event->stoppropagation();
+
+			$event->stopPropagation();
 			$event->preventDefault();
-			$this->_change_headers = true;
-		}else{
+		} else {
 			$ACT = 'preview';
 		}
 	}

--- a/action.php
+++ b/action.php
@@ -15,32 +15,22 @@ class action_plugin_diffpreview extends DokuWiki_Action_Plugin {
 	 * Register its handlers with the DokuWiki's event controller
 	 */
 	function register(Doku_Event_Handler $controller) {
-		$controller->register_hook('HTML_EDITFORM_OUTPUT', 'BEFORE',  $this, '_edit_form');
-		$controller->register_hook('ACTION_ACT_PREPROCESS', 'BEFORE',  $this, '_action_act_preprocess');
-		$controller->register_hook('TPL_ACT_UNKNOWN', 'BEFORE',  $this, '_tpl_act_changes');
+		$controller->register_hook('HTML_EDITFORM_OUTPUT', 'BEFORE', $this, '_edit_form');
+		$controller->register_hook('ACTION_ACT_PREPROCESS', 'BEFORE', $this, '_action_act_preprocess');
+		$controller->register_hook('TPL_ACT_UNKNOWN', 'BEFORE', $this, '_tpl_act_changes');
 	}
 
+	/** Add "Changes" button to the edit form */
 	function _edit_form(Doku_Event $event, $param) {
 		$preview = $event->data->findElementById('edbtn__preview');
-		if($preview) {
-			$event->data->insertElement($preview+1, form_makeButton('submit', 'changes', $this->getLang('changes'), array('id' => 'edbtn__changes')));
+		if ($preview !== false) {
+			$event->data->insertElement($preview+1,
+				form_makeButton('submit', 'changes', $this->getLang('changes'),
+					array('id' => 'edbtn__changes', 'accesskey' => 'c', 'tabindex' => '5')));
 		}
 	}
 
-	function _tpl_act_changes(Doku_Event $event, $param) {
-		global $TEXT;
-		global $PRE;
-		global $SUF;
-
-		if('changes' != $event->data) return;
-
-		html_edit($TEXT);
-		echo '<br id="scroll__here" />';
-		html_diff(con($PRE,$TEXT,$SUF));
-		$event->preventDefault();
-		return;
-	}
-
+	/** Process the "changes" action */
 	function _action_act_preprocess(Doku_Event $event, $param) {
 		global $ACT;
 		global $INFO;
@@ -59,4 +49,19 @@ class action_plugin_diffpreview extends DokuWiki_Action_Plugin {
 			$ACT = 'preview';
 		}
 	}
+
+	/** Display the "changes" page */
+	function _tpl_act_changes(Doku_Event $event, $param) {
+		global $TEXT;
+		global $PRE;
+		global $SUF;
+
+		if('changes' != $event->data) return;
+
+		html_edit($TEXT);
+		echo '<br id="scroll__here" />';
+		html_diff(con($PRE,$TEXT,$SUF));
+		$event->preventDefault();
+	}
+
 }

--- a/lang/fr/lang.php
+++ b/lang/fr/lang.php
@@ -1,0 +1,3 @@
+<?php
+
+$lang['changes'] = 'Modifications';

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   diffpreview
-author Mikhail I. Izmestev
+author Mikhail I. Izmestev, Ivan Smirnov, Tilwa Qendov
 email  izmmishao5@gmail.com
-date   2014-07-16
+date   2019-04-09
 name   diffpreview
 desc   Adds button for diff preview in edit mode.
 url    http://dokuwiki.org/plugin:diffpreview


### PR DESCRIPTION
Changes:
* Update code for Greebo
* Add accesskey to the Changes button
* Add French translation

I tested the plugin for releases of Dokuwiki between Ponder Stibbons and Greebo. They work.

I also have another commit (not included in this pull request) that adds translation for other languages based on translatewiki.org, specifically, [this page](https://translatewiki.net/w/i.php?title=Special:Translations&message=MediaWiki%3AShowdiff), but I'm not sure it's a good idea.  
What do you think ?